### PR TITLE
OME Zarr support

### DIFF
--- a/softcopy/copier.py
+++ b/softcopy/copier.py
@@ -1,0 +1,24 @@
+import logging
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+LOG = logging.getLogger(__name__)
+
+class AbstractCopier(ABC):
+    def __init__(self, source: Path, destination: Path, n_copy_procs: int, log: logging.Logger = LOG):
+        self._source = source
+        self._destination = destination
+        self._n_copy_procs = n_copy_procs
+        self._log = log
+
+    @abstractmethod
+    def start(self):
+        pass
+
+    @abstractmethod
+    def join(self):
+        pass
+
+    @abstractmethod
+    def stop(self):
+        pass

--- a/softcopy/main.py
+++ b/softcopy/main.py
@@ -38,11 +38,18 @@ def main(targets_file, verbose, nprocs):
 
     copiers = []
 
+    # TODO: actually run the copiers in parallel
+
     try:
         for target_id, target in enumerate(targets):
             source = Path(target["source"]).expanduser().absolute()
             destination = Path(target["destination"]).expanduser().absolute()
-            copier = ZarrCopier(source, destination, nprocs, LOG.getChild(f"Target {target_id}"))
+            # If the source ends with .ome.zarr, then infer ome mode for this entry:
+            
+            is_ome = source.name.endswith(".ome.zarr")
+            zarr_store_path = (source / "0") if is_ome else source
+            
+            copier = ZarrCopier(zarr_store_path, destination, nprocs, LOG.getChild(f"Target {target_id}"))
             copiers.append(copier)
             copier.start()
             copier.join()

--- a/softcopy/ome_zarr_copier.py
+++ b/softcopy/ome_zarr_copier.py
@@ -1,0 +1,69 @@
+import logging
+from pathlib import Path
+from typing import ClassVar
+import hashlib
+import shutil
+
+from .copier import AbstractCopier
+from .zarr_copier import ZarrCopier
+
+LOG = logging.getLogger(__name__)
+
+class OMEZarrCopier(AbstractCopier):
+    """
+    Wrapper around a ZarrCopier that also copies the metadata files for an OME-Zarr archive.
+    """
+
+    # Files in the ome zarr archive that, if present, should be copied to the destination.
+    # Importantly, note that these files are all small - we assume they can be loaded into memory.
+    METADATA_FILES: ClassVar[list] = [
+        ".zattrs",
+        ".zgroup",
+        ".zarray",
+        "zarr.json",
+        "daxi.json",
+    ]
+
+    _zarr_copier: ZarrCopier
+    _metadata_hashes: dict[str, str]
+
+    def __init__(self, source: Path, destination: Path, n_copy_procs: int, log: logging.Logger = LOG):
+        super().__init__(source, destination, n_copy_procs, log)
+        image_0_source = source / "0"
+        image_0_destination = destination / "0"
+        self._zarr_copier = ZarrCopier(image_0_source, image_0_destination, n_copy_procs, log)
+        self._metadata_hashes = {}
+
+    def start(self):
+        # Before starting, we make the parent directory that the image will be copied into.
+        self._destination.mkdir(parents=True, exist_ok=True)
+        self._zarr_copier.start()
+
+    def join(self):
+        self._zarr_copier.join()
+        self.copy_metadata_files()
+
+    def stop(self):
+        self._zarr_copier.stop()
+        self.copy_metadata_files()
+
+    def copy_metadata_files(self):
+        for metadata_file in self.METADATA_FILES:
+            source_file = self._source / metadata_file
+            destination_file = self._destination / metadata_file
+            if source_file.exists():
+                file_hash = hashlib.md5(source_file.read_bytes()).hexdigest()  # noqa: S324 (this hash is not cryptographically relevant)
+
+                if metadata_file in self._metadata_hashes and self._metadata_hashes[metadata_file] == file_hash:
+                    self._log.debug(f"Metadata file {source_file} (hash {file_hash}) is unchanged, skipping")
+                    continue
+
+                self._log.debug(f"Copying metadata file {source_file} (hash {file_hash}) to {destination_file}")
+
+                # The line below is not needed in this specific use case but it's forseeable that the directory might
+                # not exist for certain files... leaving this out for now.
+                # destination_file.parent.mkdir(parents=True, exist_ok=True)
+
+                shutil.copy2(source_file, destination_file)
+            else:
+                self._log.debug(f"Metadata file {source_file} does not exist, skipping")

--- a/softcopy/slow_write.py
+++ b/softcopy/slow_write.py
@@ -22,7 +22,8 @@ from . import zarr_utils
 @click.option("--method", type=click.Choice(["v2", "v3", "v3_shard"]), default="v3")
 @click.option("--sleep", type=float, default=1.0)
 @click.option("--timepoints", type=int, default=3)
-def main(source, destination, method, sleep, timepoints):
+@click.option("--no-complete-file", is_flag=True, help="Disable using a file called 'complete' to signal that the write is done", default=False)
+def main(source, destination, method, sleep, timepoints, no_complete_file):
     ensure_high_io_priority()
 
     zarr_version = zarr_utils.identify_zarr_version(source)
@@ -83,6 +84,9 @@ def main(source, destination, method, sleep, timepoints):
         print(f"Wrote stack {t + 1}/{timepoints} in {time.time() - now:.2f}s")
         time.sleep(sleep)
 
+    if no_complete_file:
+        return
+    
     # touch an empty file called "complete" to signal that the write is done to other processes
     print("writing complete file")
     (Path(destination) / "complete").touch()

--- a/softcopy/zarr_copier.py
+++ b/softcopy/zarr_copier.py
@@ -16,11 +16,12 @@ from watchdog.events import FileCreatedEvent, FileDeletedEvent, FileMovedEvent, 
 from watchdog.observers import Observer
 
 from . import zarr_utils
+from .copier import AbstractCopier
 
 LOG = logging.getLogger(__name__)
 
 
-class ZarrCopier:
+class ZarrCopier(AbstractCopier):
     _source: Path
     _destination: Path
     _queue: Queue
@@ -40,10 +41,12 @@ class ZarrCopier:
     _zarr_version: int
     _copy_count = Value("i", 0)  # The number of files that have been copied so far
 
-    def __init__(self, source: Path, destination: Path, nprocs: int = 1, log: Logger = LOG):
-        self._source = source
-        self._destination = destination
-        self._log = log
+    def __init__(self, source: Path, destination: Path, n_copy_procs: int = 1, log: Logger = LOG):
+        super().__init__(source, destination, n_copy_procs, log)
+        # self._source = source
+        # self._destination = destination
+        # self._log = log
+        # self._n_copy_procs = nprocs
 
         self._zarr_version = zarr_utils.identify_zarr_version(source, log)
         if self._zarr_version is None:
@@ -73,7 +76,6 @@ class ZarrCopier:
             self._zarr_version, self._files_nd, self._observation_finished, self._queue, self._log
         )
         self._observer.schedule(event_handler, source, recursive=True)
-        self._n_copy_procs = nprocs
         self._copy_procs = []
 
     def start(self):

--- a/softcopy/zarr_utils.py
+++ b/softcopy/zarr_utils.py
@@ -25,7 +25,7 @@ def identify_zarr_version(archive_path: Path, log: Logger = LOG) -> Optional[Lit
         metadata_file = archive_path / candidate_file
 
         if metadata_file.exists():
-            with metadata_file.open("r") as f:
+            with open(metadata_file) as f:
                 metadata = json.load(f)
             zarr_format = metadata.get("zarr_format")
             if zarr_format in KNOWN_VERSIONS:

--- a/tests/test_softcopy.py
+++ b/tests/test_softcopy.py
@@ -1,6 +1,7 @@
 import time
 from multiprocessing import Process
 from pathlib import Path
+import shutil
 
 import numpy as np
 import pytest
@@ -12,12 +13,12 @@ import softcopy.main
 import softcopy.slow_write
 
 
-def run_slow_write(dummy_path: Path, input_path: Path):
-    softcopy.slow_write.main([str(dummy_path), str(input_path), "--method", "v2"], standalone_mode=False)
+def run_slow_write(dummy_path: Path, input_path: Path, no_complete_file: bool = False):
+    softcopy.slow_write.main([str(dummy_path), str(input_path), "--method", "v2", "--no-complete-file" if no_complete_file else "--"], standalone_mode=False)
 
 
 def run_softcopy(targets_file_path: Path):
-    softcopy.main.main([str(targets_file_path)], standalone_mode=False)
+    softcopy.main.main([str(targets_file_path),], standalone_mode=False)
 
 
 def create_targets_yaml(targets_file_path: Path, input_path: Path, output_path: Path):
@@ -77,6 +78,85 @@ def test_slow_write_and_softcopy(workspace, dummy_zarr_path, create_zarr2_archiv
     }).result()
 
     assert (output_path / ".zarray").exists()
+    copied_dataset = ts.open({
+        "driver": "zarr",
+        "kvstore": {"driver": "file", "path": str(output_path)},
+    }).result()
+
+    assert np.all(np.equal(slow_write_output[:].read().result(), copied_dataset[:].read().result()))
+
+# In the tests above, we just test copying a regular zarr archive. However, we also need limited support for ome-zarr FOV data.
+# Specifically, the ome-zarr subset that is written by DaXi. This looks like the following:
+# aquisition.ome.zarr/
+# - .zgroup # .zgroup and .zattrs are modified only at the acquisition start
+# - .zattrs
+# - daxi.json # daxi.json is appended to at each timepoint
+# - daxi.json.temp # Sometimes exists, doesn't need to be copied
+# - 0/ # this is a normal, /-delimited zarr 2 archive.
+#   - .zarray
+#   - 0/
+#     - 0/
+#     - ...
+# This test is thus almost the same as the previous one, but with a more complicated skeleton. Additionally, as slow_write can only
+# output zarr (not ome zarr), we just use slow write to output to the 0/ folder, and then invoke softcopy on the entire .ome.zarr
+# folder.
+def test_slow_write_and_softcopy_ome_zarr(workspace, dummy_zarr_path, create_zarr2_archive):
+    # Construct a dummy acquisition
+    input_path = workspace / "input.ome.zarr"
+    input_path.mkdir()
+    (input_path / ".zgroup").write_text(".zgroup")
+    (input_path / ".zattrs").write_text(".zattrs")
+
+    output_path = workspace / "output.ome.zarr"
+    targets_file_path = workspace / "targets.yaml"
+
+    create_targets_yaml(targets_file_path, input_path, output_path)
+
+    slow_write_process = Process(target=run_slow_write, args=(dummy_zarr_path, input_path / "0", True))
+    slow_write_process.start()
+
+    try:
+        wait_for_file(input_path / "0" / ".zarray")
+    except TimeoutError:
+        slow_write_process.terminate()
+        pytest.fail("slow_write process did not start in time")
+
+    # Start softcopy and disable the complete file so that we can tamper with daxi.json
+    # before the write is complete
+    softcopy_process = Process(target=run_softcopy, args=(targets_file_path,))
+    softcopy_process.start()
+
+    # Wait for all of the data to be done writing
+    slow_write_process.join(timeout=120)
+    if slow_write_process.is_alive():
+        slow_write_process.terminate()
+        pytest.fail("slow_write process did not complete in 2 minutes")
+
+    # Modify daxi.json via daxi.json.temp and shutil.move
+    daxi_json_temp = input_path / "daxi.json.temp"
+    daxi_json = input_path / "daxi.json"
+    daxi_json_temp.write_text("daxi.json.temp")
+    shutil.move(daxi_json_temp, daxi_json)
+
+    # Create the complete file to signal that the write is done
+    (input_path / "complete").touch()
+
+    softcopy_process.join(timeout=120)
+
+    if softcopy_process.is_alive():
+        softcopy_process.terminate()
+        pytest.fail("softcopy process did not complete in 2 minutes")
+
+    slow_write_output = ts.open({
+        "driver": "zarr",
+        "kvstore": {"driver": "file", "path": str(input_path / "0")},
+    }).result()
+
+    # assert (output_path / ".zgroup").exists() and (output_path / ".zgroup").read_text() == ".zgroup"
+    # assert (output_path / ".zattrs").exists() and (output_path / ".zattrs").read_text() == ".zattrs"
+    # assert (output_path / "daxi.json").exists() and (output_path / "daxi.json").read_text() == "daxi.json"
+    # assert not (output_path / "daxi.json.temp").exists()
+
     copied_dataset = ts.open({
         "driver": "zarr",
         "kvstore": {"driver": "file", "path": str(output_path)},

--- a/tests/test_softcopy.py
+++ b/tests/test_softcopy.py
@@ -135,7 +135,7 @@ def test_slow_write_and_softcopy_ome_zarr(workspace, dummy_zarr_path, create_zar
     # Modify daxi.json via daxi.json.temp and shutil.move
     daxi_json_temp = input_path / "daxi.json.temp"
     daxi_json = input_path / "daxi.json"
-    daxi_json_temp.write_text("daxi.json.temp")
+    daxi_json_temp.write_text("daxi.json")
     shutil.move(daxi_json_temp, daxi_json)
 
     # Create the complete file to signal that the write is done
@@ -159,7 +159,7 @@ def test_slow_write_and_softcopy_ome_zarr(workspace, dummy_zarr_path, create_zar
 
     copied_dataset = ts.open({
         "driver": "zarr",
-        "kvstore": {"driver": "file", "path": str(output_path)},
+        "kvstore": {"driver": "file", "path": str(output_path / "0")},
     }).result()
 
     assert np.all(np.equal(slow_write_output[:].read().result(), copied_dataset[:].read().result()))

--- a/tests/test_softcopy.py
+++ b/tests/test_softcopy.py
@@ -139,7 +139,7 @@ def test_slow_write_and_softcopy_ome_zarr(workspace, dummy_zarr_path, create_zar
     shutil.move(daxi_json_temp, daxi_json)
 
     # Create the complete file to signal that the write is done
-    (input_path / "complete").touch()
+    (input_path / "0" / "complete").touch()
 
     softcopy_process.join(timeout=120)
 
@@ -152,10 +152,10 @@ def test_slow_write_and_softcopy_ome_zarr(workspace, dummy_zarr_path, create_zar
         "kvstore": {"driver": "file", "path": str(input_path / "0")},
     }).result()
 
-    # assert (output_path / ".zgroup").exists() and (output_path / ".zgroup").read_text() == ".zgroup"
-    # assert (output_path / ".zattrs").exists() and (output_path / ".zattrs").read_text() == ".zattrs"
-    # assert (output_path / "daxi.json").exists() and (output_path / "daxi.json").read_text() == "daxi.json"
-    # assert not (output_path / "daxi.json.temp").exists()
+    assert (output_path / ".zgroup").exists() and (output_path / ".zgroup").read_text() == ".zgroup"
+    assert (output_path / ".zattrs").exists() and (output_path / ".zattrs").read_text() == ".zattrs"
+    assert (output_path / "daxi.json").exists() and (output_path / "daxi.json").read_text() == "daxi.json"
+    assert not (output_path / "daxi.json.temp").exists()
 
     copied_dataset = ts.open({
         "driver": "zarr",

--- a/tests/test_zarr_copier.py
+++ b/tests/test_zarr_copier.py
@@ -17,7 +17,7 @@ def test_zarr_copier(workspace, dummy_zarr_path):
     zarr_json = {"zarr_format": 2, "shape": shape, "chunks": chunks}
     (dummy_zarr_path / ".zarray").write_text(json.dumps(zarr_json))
 
-    copier = ZarrCopier(dummy_zarr_path, destination, nprocs=1)
+    copier = ZarrCopier(dummy_zarr_path, destination, n_copy_procs=1)
     copier.start()
 
     time.sleep(1)


### PR DESCRIPTION
This is a slight shim to enable support for copying OME Zarr FOV images from DaXi. I am very clear in how I phrase that, because it is not general OME Zarr support - this feature is really only for use in house. Specifically, it supports copying this structure:

- _____.ome.zarr
  - .zgroup
  - .zattrs
  - daxi.json
  - 0/ (a regular zarr array)
     - .zarray
     - .0/ ...
